### PR TITLE
Update quiver hashcode dependency

### DIFF
--- a/lib/notus/src/document/attributes.dart
+++ b/lib/notus/src/document/attributes.dart
@@ -1,8 +1,9 @@
 // Copyright (c) 2018, the Zefyr project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
+import 'dart:ui' show hashList, hashValues;
 import 'package:collection/collection.dart';
-import 'package:quiver_hashcode/hashcode.dart';
 
 /// Scope of a style attribute, defines context in which an attribute can be
 /// applied.
@@ -186,7 +187,7 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
   }
 
   @override
-  int get hashCode => hash3(key, scope, value);
+  int get hashCode => hashValues(key, scope, value);
 
   @override
   String toString() => '$key: $value';
@@ -314,8 +315,8 @@ class NotusStyle {
 
   @override
   int get hashCode {
-    final hashes = _data.entries.map((entry) => hash2(entry.key, entry.value));
-    return hashObjects(hashes);
+    final hashes = _data.entries.map((entry) => hashValues(entry.key, entry.value));
+    return hashList(hashes);
   }
 
   @override
@@ -452,11 +453,11 @@ class EmbedAttribute extends NotusAttribute<Map<String, dynamic>> {
     final objects = [key, scope];
     if (value != null) {
       final valueHashes =
-          value.entries.map((entry) => hash2(entry.key, entry.value));
+          value.entries.map((entry) => hashValues(entry.key, entry.value));
       objects.addAll(valueHashes);
     } else {
       objects.add(value);
     }
-    return hashObjects(objects);
+    return hashList(objects);
   }
 }

--- a/lib/quill_delta/quill_delta.dart
+++ b/lib/quill_delta/quill_delta.dart
@@ -5,9 +5,9 @@
 library quill_delta;
 
 import 'dart:math' as math;
+import 'dart:ui' show hashList, hashValues;
 
 import 'package:collection/collection.dart';
-import 'package:quiver_hashcode/hashcode.dart';
 
 const _attributeEquality = MapEquality<String, dynamic>(
   keys: DefaultEquality<String>(),
@@ -144,10 +144,10 @@ class Operation {
   int get hashCode {
     if (_attributes != null && _attributes.isNotEmpty) {
       int attrsHash =
-          hashObjects(_attributes.entries.map((e) => hash2(e.key, e.value)));
-      return hash3(key, value, attrsHash);
+          hashList(_attributes.entries.map((e) => hashValues(e.key, e.value)));
+      return hashValues(key, value, attrsHash);
     }
-    return hash2(key, value);
+    return hashValues(key, value);
   }
 
   @override
@@ -282,7 +282,7 @@ class Delta {
   }
 
   @override
-  int get hashCode => hashObjects(_operations);
+  int get hashCode => hashList(_operations);
 
   /// Retain [count] of characters from current position.
   void retain(int count, [Map<String, dynamic> attributes]) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: "direct main"
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,28 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
-  quiver_hashcode:
-    dependency: "direct main"
-    description:
-      name: quiver_hashcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.0"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,56 +92,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,13 +12,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  quiver_hashcode: ^2.0.0
   collection: ^1.14.13
   meta: ^1.2.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-flutter:
-


### PR DESCRIPTION
Development on the quiver_* subpackages has been discontinued in favour
of the main quiver package at https://github.com/~/quiver-dart. The
code itself is identical, but is more actively maintained.

Since this package depends on Flutter, I've migrated instead to the hash
functions in dart:ui. This allows you to drop the dependency on quiver
entirely.