### PR TITLE
"a" replace regex to handle pre-post attributes

### DIFF
--- a/lib/quill_markdown.dart
+++ b/lib/quill_markdown.dart
@@ -88,7 +88,8 @@ String markdownToQuill(String content) {
         .replaceAll('"block":"ul"', '"list":"bullet"')
         .replaceAll('"block":"ol"', '"list":"ordered"')
         .replaceAll('"block":"code"', '"code-block":true')
-        .replaceAll(',"attributes":{"a":"', ',"attributes":{"link":"')
+        .replaceAllMapped(RegExp(r',"attributes":{(.*?)"a":"(.+?)"(.*?)}'),
+            (Match m) => ',"attributes":{${m[1]}"link":"${m[2]}"${m[3]}}')
         .replaceAll('{"insert":"​","attributes":{"embed":{"type":"hr"}}},', '')
         .replaceAll('{"insert":"​","attributes":{"embed":{"type":"hr"}}}', '');
   } catch (error) {


### PR DESCRIPTION
Thanks for this great package!

I noticed links weren't being converted in my doc if they had other attributes before the "a":

```
  "insert": "Google",
  "attributes": {
    "bold": true,
    "a": "https://google.com/"
  }
```

I added a Regex to account for this.