### PR TITLE
Feature/null safety

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -15,9 +15,9 @@ class _HomePageState extends State<HomePage> {
           onPressed: () {
             String content =
                 '[{"insert":"Heading"},{"insert":"\\n","attributes":{"header":1}},{"insert":"bold","attributes":{"bold":true}},{"insert":"\\n"},{"insert":"bold and italic","attributes":{"bold":true,"italic":true}},{"insert":"\\nsome code"},{"insert":"\\n","attributes":{"code-block":true}},{"insert":"A quote"},{"insert":"\\n","attributes":{"blockquote":true}},{"insert":"ordered list"},{"insert":"\\n","attributes":{"list":"ordered"}},{"insert":"unordered list"},{"insert":"\\n","attributes":{"list":"bullet"}},{"insert":"link","attributes":{"link":"pub.dev/packages/quill_markdown"}},{"insert":"\\n"}]';
-            content = quillToMarkdown(content);
+            content = quillToMarkdown(content)!;
             print(content);
-            content = markdownToQuill(content);
+            content = markdownToQuill(content)!;
             print(content);
           },
           child: Text('Convert')),

--- a/lib/notus/src/convert/markdown.dart
+++ b/lib/notus/src/convert/markdown.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 import 'package:quill_markdown/notus/notus.dart';
 import 'package:quill_markdown/quill_delta/quill_delta.dart';
 
-class NotusMarkdownCodec extends Codec<Delta, String> {
+class NotusMarkdownCodec extends Codec<Delta, String?> {
   const NotusMarkdownCodec();
 
   @override
@@ -18,7 +18,7 @@ class NotusMarkdownCodec extends Codec<Delta, String> {
 }
 
 class _NotusMarkdownDecoder extends Converter<String, Delta> {
-  final List<Map<String, dynamic>> _attributesByStyleLength = [
+  final List<Map<String, dynamic>?> _attributesByStyleLength = [
     null,
     {'i': true}, // _
     {'b': true}, // **
@@ -41,7 +41,7 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     final delta = Delta();
 
     if (_allLinesEmpty(lines)) {
-      Map<String, dynamic> style;
+      Map<String, dynamic>? style;
       _handleSpan(lines[0], delta, true, style);
     } else {
       for (var line in lines) {
@@ -62,8 +62,7 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     return true;
   }
 
-  void _handleLine(String line, Delta delta,
-      [Map<String, dynamic> attributes, bool isBlock]) {
+  void _handleLine(String line, Delta delta, [Map<String, dynamic>? attributes, bool? isBlock]) {
     if (_handleBlockQuote(line, delta, attributes)) {
       return;
     }
@@ -81,8 +80,7 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
 
   /// Markdown supports headings and blocks within blocks (except for within code)
   /// but not blocks within headers, or ul within
-  bool _handleBlock(String line, Delta delta,
-      [Map<String, dynamic> attributes]) {
+  bool _handleBlock(String line, Delta delta, [Map<String, dynamic>? attributes]) {
     var match;
 
     match = _codeRegExp.matchAsPrefix(line);
@@ -92,9 +90,7 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     }
     if (_inBlockStack) {
       delta.insert(
-          line + '\n',
-          NotusAttribute.code
-              .toJson()); // TODO: replace with?: {'quote': true})
+          line + '\n', NotusAttribute.code.toJson()); // TODO: replace with?: {'quote': true})
       // Don't bother testing for code blocks within block stacks
       return true;
     }
@@ -108,13 +104,11 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
   }
 
   /// all blocks are supported within bq
-  bool _handleBlockQuote(String line, Delta delta,
-      [Map<String, dynamic> attributes]) {
+  bool _handleBlockQuote(String line, Delta delta, [Map<String, dynamic>? attributes]) {
     var match = _bqRegExp.matchAsPrefix(line);
     if (match != null) {
-      var span = match.group(1);
-      var newAttributes =
-          NotusAttribute.bq.toJson(); // NotusAttribute.bq.toJson();
+      var span = match.group(1)!;
+      var newAttributes = NotusAttribute.bq.toJson(); // NotusAttribute.bq.toJson();
       if (attributes != null) {
         newAttributes.addAll(attributes);
       }
@@ -126,13 +120,12 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
   }
 
   /// ol is supported within ol and bq, but not supported within ul
-  bool _handleOrderedList(String line, Delta delta,
-      [Map<String, dynamic> attributes]) {
+  bool _handleOrderedList(String line, Delta delta, [Map<String, dynamic>? attributes]) {
     var match = _olRegExp.matchAsPrefix(line);
     if (match != null) {
 // TODO: support nesting
 //      var depth =  match.group(1).length / 3;
-      var span = match.group(2);
+      var span = match.group(2)!;
       var newAttributes = NotusAttribute.ol.toJson();
       if (attributes != null) {
         newAttributes.addAll(attributes);
@@ -144,12 +137,11 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     return false;
   }
 
-  bool _handleUnorderedList(String line, Delta delta,
-      [Map<String, dynamic> attributes]) {
+  bool _handleUnorderedList(String line, Delta delta, [Map<String, dynamic>? attributes]) {
     var match = _ulRegExp.matchAsPrefix(line);
     if (match != null) {
 //      var depth = match.group(1).length / 3;
-      var span = match.group(2);
+      var span = match.group(2)!;
       var newAttributes = NotusAttribute.ul.toJson();
       if (attributes != null) {
         newAttributes.addAll(attributes);
@@ -161,11 +153,10 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     return false;
   }
 
-  bool _handleHeading(String line, Delta delta,
-      [Map<String, dynamic> attributes]) {
+  bool _handleHeading(String line, Delta delta, [Map<String, dynamic>? attributes]) {
     var match = _headingRegExp.matchAsPrefix(line);
     if (match != null) {
-      var level = match.group(1).length;
+      var level = match.group(1)!.length;
       var newAttributes = <String, dynamic>{
         'heading': level
       }; // NotusAttribute.heading.withValue(level).toJson();
@@ -173,7 +164,7 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
         newAttributes.addAll(attributes);
       }
 
-      var span = match.group(2);
+      var span = match.group(2)!;
       // TODO: true or false?
       _handleSpan(span, delta, true, newAttributes, true);
 //      delta.insert('\n', attribute.toJson());
@@ -183,9 +174,8 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     return false;
   }
 
-  void _handleSpan(String span, Delta delta, bool addNewLine,
-      Map<String, dynamic> outerStyle,
-      [bool isBlock]) {
+  void _handleSpan(String span, Delta delta, bool addNewLine, Map<String, dynamic>? outerStyle,
+      [bool? isBlock]) {
     var start = _handleStyles(span, delta, outerStyle);
     span = span.substring(start);
 
@@ -210,7 +200,7 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     }
   }
 
-  int _handleStyles(String span, Delta delta, Map<String, dynamic> outerStyle) {
+  int _handleStyles(String span, Delta delta, Map<String, dynamic>? outerStyle) {
     var start = 0;
 
     var matches = _styleRegExp.allMatches(span);
@@ -219,26 +209,20 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
         var validInlineStyles = _getValidInlineStyles(outerStyle);
         if (span.substring(match.start - 1, match.start) == '[') {
           var text = span.substring(start, match.start - 1);
-          validInlineStyles != null
-              ? delta.insert(text, validInlineStyles)
-              : delta.insert(text);
+          validInlineStyles != null ? delta.insert(text, validInlineStyles) : delta.insert(text);
           start = match.start -
               1 +
-              _handleLinks(
-                  span.substring(match.start - 1), delta, validInlineStyles);
+              _handleLinks(span.substring(match.start - 1), delta, validInlineStyles);
           return;
         } else {
           var text = span.substring(start, match.start);
 
-          validInlineStyles != null
-              ? delta.insert(text, validInlineStyles)
-              : delta.insert(text);
+          validInlineStyles != null ? delta.insert(text, validInlineStyles) : delta.insert(text);
         }
       }
 
-      var text = match.group(2);
-      var newStyle = Map<String, dynamic>.from(
-          _attributesByStyleLength[match.group(1).length]);
+      var text = match.group(2)!;
+      var newStyle = Map<String, dynamic>.from(_attributesByStyleLength[match.group(1)!.length]!);
 
       var validInlineStyles = _getValidInlineStyles(outerStyle);
       if (validInlineStyles != null) {
@@ -252,8 +236,8 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     return start;
   }
 
-  Map<String, dynamic> _getValidInlineStyles(Map<String, dynamic> outerStyle) {
-    Map<String, dynamic> leafStyles;
+  Map<String, dynamic>? _getValidInlineStyles(Map<String, dynamic>? outerStyle) {
+    Map<String, dynamic>? leafStyles;
 
     if (outerStyle == null) {
       return null;
@@ -268,15 +252,13 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
     }
 
     if (outerStyle.containsKey(NotusAttribute.link.key)) {
-      leafStyles = {
-        NotusAttribute.link.key: outerStyle[NotusAttribute.link.key]
-      };
+      leafStyles = {NotusAttribute.link.key: outerStyle[NotusAttribute.link.key]};
     }
 
     return leafStyles;
   }
 
-  int _handleLinks(String span, Delta delta, Map<String, dynamic> outerStyle) {
+  int _handleLinks(String span, Delta delta, Map<String, dynamic>? outerStyle) {
     var start = 0;
 
     var matches = _linkRegExp.allMatches(span);
@@ -286,7 +268,7 @@ class _NotusMarkdownDecoder extends Converter<String, Delta> {
         delta.insert(text); //, outerStyle);
       }
 
-      var text = match.group(1);
+      var text = match.group(1)!;
       var href = match.group(2);
       var newAttributes = <String, dynamic>{
         'a': href
@@ -319,7 +301,7 @@ class _NotusMarkdownEncoder extends Converter<Delta, String> {
     final iterator = DeltaIterator(input);
     final buffer = StringBuffer();
     final lineBuffer = StringBuffer();
-    NotusAttribute<String> currentBlockStyle;
+    NotusAttribute<String?>? currentBlockStyle;
     var currentInlineStyle = NotusStyle();
     var currentBlockLines = <String>[];
 
@@ -333,7 +315,7 @@ class _NotusMarkdownEncoder extends Converter<Delta, String> {
       return true;
     }
 
-    void _handleBlock(NotusAttribute<String> blockStyle) {
+    void _handleBlock(NotusAttribute<String?>? blockStyle) {
       if (currentBlockLines.isEmpty) {
         return; // Empty block
       }
@@ -360,13 +342,12 @@ class _NotusMarkdownEncoder extends Converter<Delta, String> {
       buffer.writeln();
     }
 
-    void _handleSpan(String text, Map<String, dynamic> attributes) {
+    void _handleSpan(String text, Map<String, dynamic>? attributes) {
       final style = NotusStyle.fromJson(attributes);
-      currentInlineStyle =
-          _writeInline(lineBuffer, text, style, currentInlineStyle);
+      currentInlineStyle = _writeInline(lineBuffer, text, style, currentInlineStyle);
     }
 
-    void _handleLine(Map<String, dynamic> attributes) {
+    void _handleLine(Map<String, dynamic>? attributes) {
       final style = NotusStyle.fromJson(attributes);
       final lineBlock = style.get(NotusAttribute.block);
       if (lineBlock == currentBlockStyle) {
@@ -383,7 +364,7 @@ class _NotusMarkdownEncoder extends Converter<Delta, String> {
 
     while (iterator.hasNext) {
       final op = iterator.next();
-      final lf = op.data.indexOf('\n');
+      final lf = op!.data.indexOf('\n');
       if (lf == -1) {
         _handleSpan(op.data, op.attributes);
       } else {
@@ -432,8 +413,8 @@ class _NotusMarkdownEncoder extends Converter<Delta, String> {
     return ' ' * (text.length - result.length);
   }
 
-  NotusStyle _writeInline(StringBuffer buffer, String text, NotusStyle style,
-      NotusStyle currentStyle) {
+  NotusStyle _writeInline(
+      StringBuffer buffer, String text, NotusStyle style, NotusStyle currentStyle) {
     // First close any current styles if needed
     for (var value in currentStyle.values) {
       if (value.scope == NotusAttributeScope.line) continue;
@@ -457,18 +438,17 @@ class _NotusMarkdownEncoder extends Converter<Delta, String> {
     return style;
   }
 
-  void _writeAttribute(StringBuffer buffer, NotusAttribute attribute,
-      {bool close = false}) {
+  void _writeAttribute(StringBuffer buffer, NotusAttribute? attribute, {bool close = false}) {
     if (attribute == NotusAttribute.bold) {
       _writeBoldTag(buffer);
     } else if (attribute == NotusAttribute.italic) {
       _writeItalicTag(buffer);
-    } else if (attribute.key == NotusAttribute.link.key) {
-      _writeLinkTag(buffer, attribute as NotusAttribute<String>, close: close);
+    } else if (attribute!.key == NotusAttribute.link.key) {
+      _writeLinkTag(buffer, attribute as NotusAttribute<String?>?, close: close);
     } else if (attribute.key == NotusAttribute.heading.key) {
-      _writeHeadingTag(buffer, attribute as NotusAttribute<int>);
+      _writeHeadingTag(buffer, attribute as NotusAttribute<int?>);
     } else if (attribute.key == NotusAttribute.block.key) {
-      _writeBlockTag(buffer, attribute as NotusAttribute<String>, close: close);
+      _writeBlockTag(buffer, attribute as NotusAttribute<String?>?, close: close);
     } else {
       throw ArgumentError('Cannot handle $attribute');
     }
@@ -482,22 +462,20 @@ class _NotusMarkdownEncoder extends Converter<Delta, String> {
     buffer.write(kItalic);
   }
 
-  void _writeLinkTag(StringBuffer buffer, NotusAttribute<String> link,
-      {bool close = false}) {
+  void _writeLinkTag(StringBuffer buffer, NotusAttribute<String?>? link, {bool close = false}) {
     if (close) {
-      buffer.write('](${link.value})');
+      buffer.write('](${link!.value})');
     } else {
       buffer.write('[');
     }
   }
 
-  void _writeHeadingTag(StringBuffer buffer, NotusAttribute<int> heading) {
-    var level = heading.value;
+  void _writeHeadingTag(StringBuffer buffer, NotusAttribute<int?> heading) {
+    var level = heading.value!;
     buffer.write('#' * level + ' ');
   }
 
-  void _writeBlockTag(StringBuffer buffer, NotusAttribute<String> block,
-      {bool close = false}) {
+  void _writeBlockTag(StringBuffer buffer, NotusAttribute<String?>? block, {bool close = false}) {
     if (block == NotusAttribute.code) {
       if (close) {
         buffer.write('\n```');
@@ -507,7 +485,7 @@ class _NotusMarkdownEncoder extends Converter<Delta, String> {
     } else {
       if (close) return; // no close tag needed for simple blocks.
 
-      final tag = kSimpleBlocks[block];
+      final tag = kSimpleBlocks[block!];
       buffer.write(tag);
     }
   }

--- a/lib/notus/src/document.dart
+++ b/lib/notus/src/document.dart
@@ -194,7 +194,7 @@ class NotusDocument {
   ///   for every character within this range (line-break characters excluded).
   NotusStyle collectStyle(int index, int length) {
     var result = lookupLine(index);
-    LineNode line = result.node;
+    LineNode line = result.node as LineNode;
     return line.collectStyle(result.offset, length);
   }
 
@@ -203,7 +203,7 @@ class NotusDocument {
     // TODO: prevent user from moving caret after last line-break.
     var result = _root.lookup(offset, inclusive: true);
     if (result.node is LineNode) return result;
-    BlockNode block = result.node;
+    BlockNode block = result.node as BlockNode;
     return block.lookup(result.offset, inclusive: true);
   }
 
@@ -234,7 +234,7 @@ class NotusDocument {
       } else if (op.attributes != null) {
         _root.retain(offset, op.length, attributes);
       }
-      if (!op.isDelete) offset += op.length;
+      if (!op.isDelete) offset += op.length!;
     }
     _delta = _delta.compose(change);
 
@@ -282,7 +282,7 @@ class NotusDocument {
         throw ArgumentError.value(doc,
             'Document Delta can only contain insert operations but ${op.key} found.');
       }
-      offset += op.length;
+      offset += op.length!;
     }
     // Must remove last line if it's empty and with no styles.
     // TODO: find a way for DocumentRoot to not create extra line when composing initial delta.

--- a/lib/notus/src/document/attributes.dart
+++ b/lib/notus/src/document/attributes.dart
@@ -42,9 +42,8 @@ abstract class NotusAttributeBuilder<T> implements NotusAttributeKey<T> {
   @override
   final String key;
   final NotusAttributeScope scope;
-  NotusAttribute<T> get unset => NotusAttribute<T>._(key, scope, null);
-  NotusAttribute<T> withValue(T value) =>
-      NotusAttribute<T>._(key, scope, value);
+  NotusAttribute<T?> get unset => NotusAttribute<T?>._(key, scope, null);
+  NotusAttribute<T> withValue(T value) => NotusAttribute<T>._(key, scope, value);
 }
 
 /// Style attribute applicable to a segment of a Notus document.
@@ -130,10 +129,9 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
 
   static NotusAttribute _fromKeyValue(String key, dynamic value) {
     if (!_registry.containsKey(key)) {
-      throw ArgumentError.value(
-          key, 'No attribute with key "$key" registered.');
+      throw ArgumentError.value(key, 'No attribute with key "$key" registered.');
     }
-    final builder = _registry[key];
+    final builder = _registry[key]!;
     return builder.withValue(value);
   }
 
@@ -164,7 +162,7 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
   /// When composed into a rich text document, unset attributes remove
   /// associated style.
   @override
-  NotusAttribute<T> get unset => NotusAttribute<T>._(key, scope, null);
+  NotusAttribute<T?> get unset => NotusAttribute<T?>._(key, scope, null);
 
   /// Returns `true` if this attribute is an unset attribute.
   bool get isUnset => value == null;
@@ -173,17 +171,14 @@ class NotusAttribute<T> implements NotusAttributeBuilder<T> {
   bool get isInline => scope == NotusAttributeScope.inline;
 
   @override
-  NotusAttribute<T> withValue(T value) =>
-      NotusAttribute<T>._(key, scope, value);
+  NotusAttribute<T> withValue(T value) => NotusAttribute<T>._(key, scope, value);
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! NotusAttribute<T>) return false;
     NotusAttribute<T> typedOther = other;
-    return key == typedOther.key &&
-        scope == typedOther.scope &&
-        value == typedOther.value;
+    return key == typedOther.key && scope == typedOther.scope && value == typedOther.value;
   }
 
   @override
@@ -201,7 +196,7 @@ class NotusStyle {
 
   final Map<String, NotusAttribute> _data;
 
-  static NotusStyle fromJson(Map<String, dynamic> data) {
+  static NotusStyle fromJson(Map<String, dynamic>? data) {
     if (data == null) return NotusStyle();
 
     final result = data.map((String key, dynamic value) {
@@ -243,11 +238,10 @@ class NotusStyle {
   }
 
   /// Returns value of specified attribute [key] in this set.
-  T value<T>(NotusAttributeKey<T> key) => get(key).value;
+  T? value<T>(NotusAttributeKey<T> key) => get(key)!.value;
 
   /// Returns [NotusAttribute] from this set by specified [key].
-  NotusAttribute<T> get<T>(NotusAttributeKey<T> key) =>
-      _data[key.key] as NotusAttribute<T>;
+  NotusAttribute<T?>? get<T>(NotusAttributeKey<T> key) => _data[key.key] as NotusAttribute<T?>?;
 
   /// Returns collection of all attribute keys in this set.
   Iterable<String> get keys => _data.keys;
@@ -299,10 +293,10 @@ class NotusStyle {
   }
 
   /// Returns JSON-serializable representation of this style.
-  Map<String, dynamic> toJson() => _data.isEmpty
+  Map<String, dynamic>? toJson() => _data.isEmpty
       ? null
-      : _data.map<String, dynamic>((String _, NotusAttribute value) =>
-          MapEntry<String, dynamic>(value.key, value.value));
+      : _data.map<String, dynamic>(
+          (String _, NotusAttribute value) => MapEntry<String, dynamic>(value.key, value.value));
 
   @override
   bool operator ==(Object other) {
@@ -342,8 +336,7 @@ class LinkAttributeBuilder extends NotusAttributeBuilder<String> {
   const LinkAttributeBuilder._() : super._(_kLink, NotusAttributeScope.inline);
 
   /// Creates a link attribute with specified link [value].
-  NotusAttribute<String> fromString(String value) =>
-      NotusAttribute<String>._(key, scope, value);
+  NotusAttribute<String> fromString(String value) => NotusAttribute<String>._(key, scope, value);
 }
 
 /// Builder for heading attribute styles.
@@ -352,8 +345,7 @@ class LinkAttributeBuilder extends NotusAttributeBuilder<String> {
 /// [NotusAttribute.heading] instead.
 class HeadingAttributeBuilder extends NotusAttributeBuilder<int> {
   static const _kHeading = 'heading';
-  const HeadingAttributeBuilder._()
-      : super._(_kHeading, NotusAttributeScope.line);
+  const HeadingAttributeBuilder._() : super._(_kHeading, NotusAttributeScope.line);
 
   /// Level 1 heading, equivalent of `H1` in HTML.
   NotusAttribute<int> get level1 => NotusAttribute<int>._(key, scope, 1);
@@ -374,69 +366,60 @@ class BlockAttributeBuilder extends NotusAttributeBuilder<String> {
   const BlockAttributeBuilder._() : super._(_kBlock, NotusAttributeScope.line);
 
   /// Formats a block of lines as a bullet list.
-  NotusAttribute<String> get bulletList =>
-      NotusAttribute<String>._(key, scope, 'ul');
+  NotusAttribute<String> get bulletList => NotusAttribute<String>._(key, scope, 'ul');
 
   /// Formats a block of lines as a number list.
-  NotusAttribute<String> get numberList =>
-      NotusAttribute<String>._(key, scope, 'ol');
+  NotusAttribute<String> get numberList => NotusAttribute<String>._(key, scope, 'ol');
 
   /// Formats a block of lines as a code snippet, using monospace font.
-  NotusAttribute<String> get code =>
-      NotusAttribute<String>._(key, scope, 'code');
+  NotusAttribute<String> get code => NotusAttribute<String>._(key, scope, 'code');
 
   /// Formats a block of lines as a quote.
-  NotusAttribute<String> get quote =>
-      NotusAttribute<String>._(key, scope, 'quote');
+  NotusAttribute<String> get quote => NotusAttribute<String>._(key, scope, 'quote');
 }
 
-class EmbedAttributeBuilder
-    extends NotusAttributeBuilder<Map<String, dynamic>> {
-  const EmbedAttributeBuilder._()
-      : super._(EmbedAttribute._kEmbed, NotusAttributeScope.inline);
+class EmbedAttributeBuilder extends NotusAttributeBuilder<Map<String, dynamic>?> {
+  const EmbedAttributeBuilder._() : super._(EmbedAttribute._kEmbed, NotusAttributeScope.inline);
 
-  NotusAttribute<Map<String, dynamic>> get horizontalRule =>
-      EmbedAttribute.horizontalRule();
+  NotusAttribute<Map<String, dynamic>?> get horizontalRule => EmbedAttribute.horizontalRule();
 
-  NotusAttribute<Map<String, dynamic>> image(String source) =>
-      EmbedAttribute.image(source);
+  NotusAttribute<Map<String, dynamic>?> image(String source) => EmbedAttribute.image(source);
 
   @override
-  NotusAttribute<Map<String, dynamic>> get unset => EmbedAttribute._(null);
+  NotusAttribute<Map<String, dynamic>?> get unset => EmbedAttribute._(null);
 
   @override
-  NotusAttribute<Map<String, dynamic>> withValue(Map<String, dynamic> value) =>
+  NotusAttribute<Map<String, dynamic>?> withValue(Map<String, dynamic>? value) =>
       EmbedAttribute._(value);
 }
 
 /// Type of embedded content.
 enum EmbedType { horizontalRule, image }
 
-class EmbedAttribute extends NotusAttribute<Map<String, dynamic>> {
+class EmbedAttribute extends NotusAttribute<Map<String, dynamic>?> {
   static const _kValueEquality = MapEquality<String, dynamic>();
   static const _kEmbed = 'embed';
   static const _kHorizontalRuleEmbed = 'hr';
   static const _kImageEmbed = 'image';
 
-  EmbedAttribute._(Map<String, dynamic> value)
+  EmbedAttribute._(Map<String, dynamic>? value)
       : super._(_kEmbed, NotusAttributeScope.inline, value);
 
-  EmbedAttribute.horizontalRule()
-      : this._(<String, dynamic>{'type': _kHorizontalRuleEmbed});
+  EmbedAttribute.horizontalRule() : this._(<String, dynamic>{'type': _kHorizontalRuleEmbed});
 
   EmbedAttribute.image(String source)
       : this._(<String, dynamic>{'type': _kImageEmbed, 'source': source});
 
   /// Type of this embed.
-  EmbedType get type {
-    if (value['type'] == _kHorizontalRuleEmbed) return EmbedType.horizontalRule;
-    if (value['type'] == _kImageEmbed) return EmbedType.image;
+  EmbedType? get type {
+    if (value?['type'] == _kHorizontalRuleEmbed) return EmbedType.horizontalRule;
+    if (value?['type'] == _kImageEmbed) return EmbedType.image;
     assert(false, 'Unknown embed attribute value $value.');
     return null;
   }
 
   @override
-  NotusAttribute<Map<String, dynamic>> get unset => EmbedAttribute._(null);
+  NotusAttribute<Map<String, dynamic>?> get unset => EmbedAttribute._(null);
 
   @override
   bool operator ==(other) {
@@ -452,11 +435,10 @@ class EmbedAttribute extends NotusAttribute<Map<String, dynamic>> {
   int get hashCode {
     final objects = [key, scope];
     if (value != null) {
-      final valueHashes =
-          value.entries.map((entry) => hashValues(entry.key, entry.value));
+      final valueHashes = value!.entries.map((entry) => hashValues(entry.key, entry.value));
       objects.addAll(valueHashes);
     } else {
-      objects.add(value);
+      objects.add(value!);
     }
     return hashList(objects);
   }

--- a/lib/notus/src/document/block.dart
+++ b/lib/notus/src/document/block.dart
@@ -13,7 +13,7 @@ import 'node.dart';
 /// style.
 ///
 /// Block examples: lists, quotes, code snippets.
-class BlockNode extends ContainerNode<LineNode>
+class BlockNode extends ContainerNode<LineNode?>
     with StyledNodeMixin
     implements StyledNode {
   /// Creates new unmounted [BlockNode] with the same attributes.
@@ -38,7 +38,7 @@ class BlockNode extends ContainerNode<LineNode>
       final before = clone();
       insertBefore(before);
 
-      LineNode child = first;
+      LineNode child = first as LineNode;
       while (child != line) {
         child.unlink();
         before.add(child);
@@ -82,9 +82,9 @@ class BlockNode extends ContainerNode<LineNode>
       return;
     }
 
-    var block = this;
+    BlockNode block = this;
     if (!block.isFirst && block.previous is BlockNode) {
-      BlockNode prev = block.previous;
+      BlockNode prev = block.previous as BlockNode;
       if (prev.style == block.style) {
         block.moveChildren(prev);
         block.unlink();
@@ -92,7 +92,7 @@ class BlockNode extends ContainerNode<LineNode>
       }
     }
     if (!block.isLast && block.next is BlockNode) {
-      BlockNode nextBlock = block.next;
+      BlockNode nextBlock = block.next as BlockNode;
       if (nextBlock.style == block.style) {
         nextBlock.moveChildren(block);
         nextBlock.unlink();

--- a/lib/notus/src/document/leaf.dart
+++ b/lib/notus/src/document/leaf.dart
@@ -49,11 +49,11 @@ abstract class LeafNode extends Node
   ///
   /// In case a new node is actually split from this one, it inherits this
   /// node's style.
-  LeafNode splitAt(int index) {
+  LeafNode? splitAt(int index) {
     assert(index >= 0 && index <= length);
     if (index == 0) return this;
     if (index == length && isLast) return null;
-    if (index == length && !isLast) return next as LeafNode;
+    if (index == length && !isLast) return next as LeafNode?;
 
     final text = _value;
     _value = text.substring(0, index);
@@ -68,7 +68,7 @@ abstract class LeafNode extends Node
   ///
   /// Splitting logic is identical to one described in [splitAt], meaning this
   /// method may return `null`.
-  LeafNode cutAt(int index) {
+  LeafNode? cutAt(int index) {
     assert(index >= 0 && index <= length);
     final cut = splitAt(index);
     cut?.unlink();
@@ -89,13 +89,13 @@ abstract class LeafNode extends Node
         'Actual node length: ${this.length}.');
     // Since `index < this.length` (guarded by assert) below line
     // always returns a new node.
-    final target = splitAt(index);
+    final target = splitAt(index)!;
     target.splitAt(length);
     return target;
   }
 
   /// Formats this node and optimizes it with adjacent leaf nodes if needed.
-  void formatAndOptimize(NotusStyle style) {
+  void formatAndOptimize(NotusStyle? style) {
     if (style != null && style.isNotEmpty) {
       applyStyle(style);
     }
@@ -125,7 +125,7 @@ abstract class LeafNode extends Node
   }
 
   @override
-  LineNode get parent => super.parent as LineNode;
+  LineNode? get parent => super.parent as LineNode?;
 
   @override
   int get length => _value.length;
@@ -139,39 +139,39 @@ abstract class LeafNode extends Node
   String toPlainText() => _value;
 
   @override
-  void insert(int index, String value, NotusStyle style) {
+  void insert(int index, String value, NotusStyle? style) {
     assert(index >= 0 && (index <= length), 'Index: $index, Length: $length.');
     assert(value.isNotEmpty);
     final node = LeafNode(value);
     if (index == length) {
       insertAfter(node);
     } else {
-      splitAt(index).insertBefore(node);
+      splitAt(index)!.insertBefore(node);
     }
     node.formatAndOptimize(style);
   }
 
   @override
-  void retain(int index, int length, NotusStyle style) {
+  void retain(int index, int? length, NotusStyle? style) {
     if (style == null) return;
 
-    final local = math.min(this.length - index, length);
+    final local = math.min(this.length - index, length!);
     final node = isolate(index, local);
 
     final remaining = length - local;
     if (remaining > 0) {
       assert(node.next != null);
-      node.next.retain(0, remaining, style);
+      node.next!.retain(0, remaining, style);
     }
     // Optimize at the very end
     node.formatAndOptimize(style);
   }
 
   @override
-  void delete(int index, int length) {
+  void delete(int index, int? length) {
     assert(index < this.length);
 
-    final local = math.min(this.length - index, length);
+    final local = math.min(this.length - index, length!);
     final target = isolate(index, local);
     // Memorize siblings before un-linking.
     final needsOptimize = target.previous;
@@ -181,7 +181,7 @@ abstract class LeafNode extends Node
     final remaining = length - local;
     if (remaining > 0) {
       assert(actualNext != null);
-      actualNext.delete(0, remaining);
+      actualNext!.delete(0, remaining);
     }
 
     if (needsOptimize != null) needsOptimize.optimize();
@@ -198,9 +198,9 @@ abstract class LeafNode extends Node
   /// the same style.
   @override
   void optimize() {
-    var node = this;
+    LeafNode node = this;
     if (!node.isFirst) {
-      LeafNode mergeWith = node.previous;
+      LeafNode mergeWith = node.previous as LeafNode;
       if (mergeWith.style == node.style) {
         mergeWith._value += node.value;
         node.unlink();
@@ -208,7 +208,7 @@ abstract class LeafNode extends Node
       }
     }
     if (!node.isLast) {
-      LeafNode mergeWith = node.next;
+      LeafNode mergeWith = node.next as LeafNode;
       if (mergeWith.style == node.style) {
         node._value += mergeWith._value;
         mergeWith.unlink();

--- a/lib/notus/src/heuristics.dart
+++ b/lib/notus/src/heuristics.dart
@@ -46,19 +46,19 @@ class NotusHeuristics {
   });
 
   /// List of format rules in this registry.
-  final List<FormatRule> formatRules;
+  final List<FormatRule>? formatRules;
 
   /// List of insert rules in this registry.
-  final List<InsertRule> insertRules;
+  final List<InsertRule>? insertRules;
 
   /// List of delete rules in this registry.
-  final List<DeleteRule> deleteRules;
+  final List<DeleteRule>? deleteRules;
 
   /// Applies heuristic rules to specified insert operation based on current
   /// state of Notus [document].
   Delta applyInsertRules(NotusDocument document, int index, String insert) {
     final delta = document.toDelta();
-    for (var rule in insertRules) {
+    for (var rule in insertRules!) {
       final result = rule.apply(delta, index, insert);
       if (result != null) return result..trim();
     }
@@ -70,7 +70,7 @@ class NotusHeuristics {
   Delta applyFormatRules(
       NotusDocument document, int index, int length, NotusAttribute value) {
     final delta = document.toDelta();
-    for (var rule in formatRules) {
+    for (var rule in formatRules!) {
       final result = rule.apply(delta, index, length, value);
       if (result != null) return result..trim();
     }
@@ -81,7 +81,7 @@ class NotusHeuristics {
   /// state of Notus [document].
   Delta applyDeleteRules(NotusDocument document, int index, int length) {
     final delta = document.toDelta();
-    for (var rule in deleteRules) {
+    for (var rule in deleteRules!) {
       final result = rule.apply(delta, index, length);
       if (result != null) return result..trim();
     }

--- a/lib/notus/src/heuristics/format_rules.dart
+++ b/lib/notus/src/heuristics/format_rules.dart
@@ -12,7 +12,7 @@ abstract class FormatRule {
 
   /// Applies heuristic rule to a retain (format) operation on a [document] and
   /// returns resulting [Delta].
-  Delta apply(Delta document, int index, int length, NotusAttribute attribute);
+  Delta? apply(Delta document, int index, int length, NotusAttribute attribute);
 }
 
 /// Produces Delta with line-level attributes applied strictly to
@@ -21,7 +21,7 @@ class ResolveLineFormatRule extends FormatRule {
   const ResolveLineFormatRule() : super();
 
   @override
-  Delta apply(Delta document, int index, int length, NotusAttribute attribute) {
+  Delta? apply(Delta document, int index, int length, NotusAttribute attribute) {
     if (attribute.scope != NotusAttributeScope.line) return null;
 
     var result = Delta()..retain(index);
@@ -33,20 +33,20 @@ class ResolveLineFormatRule extends FormatRule {
     var current = 0;
     while (current < length && iter.hasNext) {
       final op = iter.next(length - current);
-      if (op.data.contains('\n')) {
+      if (op!.data.contains('\n')) {
         final delta = _applyAttribute(op.data, attribute);
         result = result.concat(delta);
       } else {
-        result.retain(op.length);
+        result.retain(op.length!);
       }
-      current += op.length;
+      current += op.length!;
     }
     // And include extra line-break after retain
     while (iter.hasNext) {
       final op = iter.next();
-      final lf = op.data.indexOf('\n');
+      final lf = op!.data.indexOf('\n');
       if (lf == -1) {
-        result..retain(op.length);
+        result..retain(op.length!);
         continue;
       }
       result..retain(lf)..retain(1, attribute.toJson());
@@ -76,7 +76,7 @@ class ResolveInlineFormatRule extends FormatRule {
   const ResolveInlineFormatRule();
 
   @override
-  Delta apply(Delta document, int index, int length, NotusAttribute attribute) {
+  Delta? apply(Delta document, int index, int length, NotusAttribute attribute) {
     if (attribute.scope != NotusAttributeScope.inline) return null;
 
     final result = Delta()..retain(index);
@@ -88,7 +88,7 @@ class ResolveInlineFormatRule extends FormatRule {
     var current = 0;
     while (current < length && iter.hasNext) {
       final op = iter.next(length - current);
-      var lf = op.data.indexOf('\n');
+      var lf = op!.data.indexOf('\n');
       if (lf != -1) {
         var pos = 0;
         while (lf != -1) {
@@ -96,11 +96,11 @@ class ResolveInlineFormatRule extends FormatRule {
           pos = lf + 1;
           lf = op.data.indexOf('\n', pos);
         }
-        if (pos < op.length) result.retain(op.length - pos, attribute.toJson());
+        if (pos < op.length!) result.retain(op.length! - pos, attribute.toJson());
       } else {
-        result.retain(op.length, attribute.toJson());
+        result.retain(op.length!, attribute.toJson());
       }
-      current += op.length;
+      current += op.length!;
     }
 
     return result;
@@ -112,7 +112,7 @@ class FormatLinkAtCaretPositionRule extends FormatRule {
   const FormatLinkAtCaretPositionRule();
 
   @override
-  Delta apply(Delta document, int index, int length, NotusAttribute attribute) {
+  Delta? apply(Delta document, int index, int length, NotusAttribute attribute) {
     if (attribute.key != NotusAttribute.link.key) return null;
     // If user selection is not collapsed we let it fallback to default rule
     // which simply applies the attribute to selected range.
@@ -127,13 +127,13 @@ class FormatLinkAtCaretPositionRule extends FormatRule {
     final before = iter.skip(index);
     final after = iter.next();
     var startIndex = index;
-    var retain = 0;
+    int retain = 0;
     if (before != null && before.hasAttribute(attribute.key)) {
-      startIndex -= before.length;
-      retain = before.length;
+      startIndex -= before.length!;
+      retain = before.length!;
     }
     if (after != null && after.hasAttribute(attribute.key)) {
-      retain += after.length;
+      retain += after.length!;
     }
     // There is no link-styled text around `index` position so it becomes a
     // no-op action.
@@ -150,7 +150,7 @@ class FormatEmbedsRule extends FormatRule {
   const FormatEmbedsRule();
 
   @override
-  Delta apply(Delta document, int index, int length, NotusAttribute attribute) {
+  Delta? apply(Delta document, int index, int length, NotusAttribute attribute) {
     // We are only interested in embed attributes
     if (attribute is! EmbedAttribute) return null;
     EmbedAttribute embed = attribute;
@@ -169,8 +169,7 @@ class FormatEmbedsRule extends FormatRule {
     }
   }
 
-  Delta _insertEmbed(
-      Delta document, int index, int length, EmbedAttribute embed) {
+  Delta _insertEmbed(Delta document, int index, int length, EmbedAttribute embed) {
     final result = Delta()..retain(index);
     final iter = DeltaIterator(document);
     final previous = iter.skip(index);
@@ -179,14 +178,14 @@ class FormatEmbedsRule extends FormatRule {
 
     // Check if [index] is on an empty line already.
     final isNewlineBefore = previous == null || previous.data.endsWith('\n');
-    final isNewlineAfter = target.data.startsWith('\n');
+    final isNewlineAfter = target?.data.startsWith('\n') ?? false;
     final isOnEmptyLine = isNewlineBefore && isNewlineAfter;
     if (isOnEmptyLine) {
       return result..insert(EmbedNode.kPlainTextPlaceholder, embed.toJson());
     }
     // We are on a non-empty line, split it (preserving style if needed)
     // and insert our embed.
-    final lineStyle = _getLineStyle(iter, target);
+    final lineStyle = _getLineStyle(iter, target!);
     if (!isNewlineBefore) {
       result..insert('\n', lineStyle);
     }
@@ -198,16 +197,15 @@ class FormatEmbedsRule extends FormatRule {
     return result;
   }
 
-  Map<String, dynamic> _getLineStyle(
-      DeltaIterator iterator, Operation current) {
+  Map<String, dynamic>? _getLineStyle(DeltaIterator iterator, Operation current) {
     if (current.data.contains('\n')) {
       return current.attributes;
     }
     // Continue looking for line-break.
-    Map<String, dynamic> attributes;
+    Map<String, dynamic>? attributes;
     while (iterator.hasNext) {
       final op = iterator.next();
-      final lf = op.data.indexOf('\n');
+      final lf = op!.data.indexOf('\n');
       if (lf >= 0) {
         attributes = op.attributes;
         break;

--- a/lib/quill_markdown.dart
+++ b/lib/quill_markdown.dart
@@ -4,7 +4,7 @@ import 'dart:convert';
 import 'package:quill_markdown/notus/convert.dart';
 import 'notus/notus.dart';
 
-String quillToMarkdown(String content) {
+String? quillToMarkdown(String content) {
   try {
     return notusMarkdown.encode(NotusDocument.fromJson(jsonDecode(content
         .replaceAll('"header":1', '"heading":1')
@@ -75,7 +75,7 @@ String quillToMarkdown(String content) {
   }
 }
 
-String markdownToQuill(String content) {
+String? markdownToQuill(String? content) {
   try {
     return jsonEncode(notusMarkdown.decode(content))
         .toString()

--- a/lib/quill_markdown.dart
+++ b/lib/quill_markdown.dart
@@ -15,7 +15,8 @@ String quillToMarkdown(String content) {
         .replaceAll('"blockquote":"true"', '"block":"quote"')
         .replaceAll('"blockquote":"quote"', '"block":"quote"')
         .replaceAll('"code-block":true', '"block":"code"')
-        .replaceAll(',"attributes":{"link":"', ',"attributes":{"a":"')
+        .replaceAllMapped(RegExp(r',"attributes":{(.*?)"link":"(.+?)"(.*?)}'),
+            (Match m) => ',"attributes":{${m[1]}"a":"${m[2]}"${m[3]}}')
         .replaceAll('{"insert":"​","attributes":{"embed":{"type":"hr"}}},', '')
         .replaceAll('{"insert":"​","attributes":{"embed":{"type":"hr"}}}', '')
         .replaceAll('"underline":true,', '')

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
@@ -143,5 +143,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/ArjanAswal/quill_markdown.git
 repository: https://github.com/ArjanAswal/quill_markdown.git
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
Here's the null safety PR mentioned in #5.

It contains the "a" link Regex approved in #4 but also the quilltoMarkdown equivalent.  I forgot to apply that one to both conversion functions, so maybe you'll want to cherry pick (https://github.com/ArjanAswal/quill_markdown/commit/62653a6aa53a96e98105a4887159d0d8ca91817e) that if you decide to maintain separate a separate branch for null safety, however you see fit.

For null safety, I mostly applied all of the dart migrate suggestions with few modifications that got it working for me.